### PR TITLE
feat: ajuste no header com ícones de bandeiras

### DIFF
--- a/src/app/components/header/header.html
+++ b/src/app/components/header/header.html
@@ -7,11 +7,11 @@
         
           <a class="navbar-brand" routerLink="/">
           
-          <img src="assets/img/logo-principal-azul-escuro-positivo.png" alt="Logo Brazucas" class="logo-icon">
+          <img src="assets/img/logo-principal-azul-escuro-positivo.png" alt="Logo Brazucas" class="logo-icon"> 
 
           </a>
 
-          <span class="logo-text">BRAZUCAS<br><span class="logo-subtitle">NO BOARD</span></span>
+         <!--  <span class="logo-text">BRAZUCAS<br><span class="logo-subtitle">NO BOARD</span></span> --> 
         </div>
       </div>
       
@@ -29,15 +29,14 @@
         
       </div>
 
-      <div class="header-actions">
-        <div class="language-selector">
-          <select (change)="onLanguageChange($event)" [value]="currentLanguage">
-            <option *ngFor="let lang of availableLanguages" [value]="lang.code">
-              {{ lang.name }}
-            </option>
-          </select>
-        </div>
-      </div>
+      <div class="language-selector">
+  <select (change)="onLanguageChange($event)" [value]="currentLanguage">
+    <option *ngFor="let lang of availableLanguages" [value]="lang.code">
+      {{ lang.emoji }}
+    </option>
+  </select>
+</div>
+
       
       <button 
         class="navbar-toggle" 

--- a/src/app/components/header/header.scss
+++ b/src/app/components/header/header.scss
@@ -23,7 +23,7 @@
 }
 
 .logo-icon {
-  height: 80px;
+  height: 100px;
   width: auto;
 }
 

--- a/src/app/components/header/header.ts
+++ b/src/app/components/header/header.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { LanguageService, LanguageContent } from '../../services/language.service';
 
@@ -9,27 +9,31 @@ import { LanguageService, LanguageContent } from '../../services/language.servic
   templateUrl: './header.html',
   styleUrl: './header.scss'
 })
-export class HeaderComponent {
+export class HeaderComponent implements OnInit {
   isMenuOpen = false;
   content!: LanguageContent;
   currentLanguage: string = 'pt';
-  availableLanguages: Array<{code: string, name: string}> = [];
+
+  availableLanguages = [
+    { code: 'pt', name: 'Português', emoji: '🇧🇷' },
+    { code: 'es', name: 'Español', emoji: '🇪🇸' },
+    { code: 'en', name: 'English', emoji: '🇺🇸' },
+  ];
 
   constructor(private languageService: LanguageService) {}
 
-   ngOnInit(): void {
+  ngOnInit(): void {
     this.languageService.currentLanguage$.subscribe(lang => {
       this.currentLanguage = lang;
       this.content = this.languageService.getContent();
     });
-    this.availableLanguages = this.languageService.getAvailableLanguages();
   }
 
   toggleMenu(): void {
     this.isMenuOpen = !this.isMenuOpen;
   }
 
-  closeMenu() {
+  closeMenu(): void {
     this.isMenuOpen = false;
   }
 
@@ -38,4 +42,5 @@ export class HeaderComponent {
     this.languageService.setLanguage(selectElement.value);
   }
 }
+
 

--- a/src/index.html
+++ b/src/index.html
@@ -11,6 +11,7 @@
 
   
   <!-- Google Fonts -->
+   
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet">

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,5 +2,6 @@ import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app';
 
+
 bootstrapApplication(AppComponent, appConfig)
   .catch((err) => console.error(err));

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,4 +1,5 @@
 /* Global Styles */
+
 * {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
Substituição dos nomes de idiomas no <select> do header por emojis de bandeiras (🇧🇷, 🇪🇸, 🇺🇸), mantendo a estrutura nativa do select.

Atualização do header.component.ts para usar a propriedade emoji em vez de name, garantindo compatibilidade com o HTML.

Correção de bindings e tipagem no TypeScript.

Código organizado para manter o suporte ao LanguageService existente.

Branch criada: developer

📸 Preview:
Antes:
Português | Español | English

Depois:
🇧🇷 | 🇪🇸 | 🇺🇸

✅ Objetivo:
Deixar o seletor de idioma mais visual e intuitivo, usando emojis como ícones.
Mantém compatibilidade com navegação e troca dinâmica de idiomas.

🧪 Testes manuais realizados:
 Troca de idioma via <select> funcionando normalmente

 Emojis exibidos corretamente em todos os navegadores testados

 Responsividade e estilo mantidos no header

